### PR TITLE
Load complete font

### DIFF
--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -15,31 +15,34 @@ struct mrb_Glyph
 {
   FT_ULong codepoint;
   FT_BitmapGlyph bmp;
-  size_t offset;
   Rectangle rect;
   Vector2 advance;
   Vector2 margin;
   struct mrb_Glyph *left;
   struct mrb_Glyph *right;
-  mrb_int height;
+  mrb_int node_height;
+  size_t row;
+};
+
+struct mrb_GlyphMap
+{
+  size_t count;
+  struct mrb_Glyph *root;
+};
+
+struct mrb_FontMetrics
+{
+  size_t max_width;
+  size_t min_height;
+  size_t max_height;
 };
 
 struct mrb_Font
 {
   FT_Face face;
   mrb_int size;
-  struct 
-  {
-    size_t count;
-    struct mrb_Glyph *root;
-  } glyphs;
-  struct
-  {
-    size_t max_width;
-    size_t min_height;
-    size_t max_height;
-    size_t total_width;
-  } metrics;
+  struct mrb_GlyphMap glyphs;
+  struct mrb_FontMetrics metrics;
   Texture2D texture;
 };
 

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -37,6 +37,7 @@ struct mrb_Font
     FT_UInt max_width;
     FT_UInt min_height;
     FT_UInt max_height;
+    FT_UInt total_width;
   } metrics;
   struct 
   {

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -11,14 +11,41 @@
 extern "C" {
 #endif
 
-struct mrb_Font;
-
 struct mrb_Glyph
 {
+  FT_ULong codepoint;
   FT_BitmapGlyph bmp;
-  Texture2D texture;
   Rectangle rect;
+  Vector2 advance;
+  Vector2 margin;
+  struct mrb_Glyph *left;
+  struct mrb_Glyph *right;
+  mrb_int height;
 };
+
+struct mrb_Font
+{
+  FT_Face face;
+  mrb_int size;
+  struct 
+  {
+    size_t count;
+    struct mrb_Glyph *root;
+  } glyphs;
+  struct
+  {
+    FT_UInt max_width;
+    FT_UInt min_height;
+    FT_UInt max_height;
+  } metrics;
+  struct 
+  {
+    size_t width;
+    size_t height;
+    Texture2D texture;
+  } atlas;
+};
+
 
 void
 mrb_carbuncle_font_init(mrb_state *mrb);

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -34,10 +34,10 @@ struct mrb_Font
   } glyphs;
   struct
   {
-    FT_UInt max_width;
-    FT_UInt min_height;
-    FT_UInt max_height;
-    FT_UInt total_width;
+    size_t max_width;
+    size_t min_height;
+    size_t max_height;
+    size_t total_width;
   } metrics;
   struct 
   {

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -69,6 +69,9 @@ mrb_carbuncle_font_calculate_size(size_t len, FT_BitmapGlyph *bmps);
 void
 mrb_carbuncle_font_destroy_glyphs(mrb_state *mrb, size_t len, FT_BitmapGlyph *bmps);
 
+struct mrb_Glyph *
+mrb_carbuncle_font_get_glyph(struct mrb_Font *font, FT_UInt codepoint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -56,18 +56,6 @@ mrb_carbuncle_get_font(mrb_state *mrb, mrb_value obj);
 mrb_bool
 mrb_carbuncle_font_p(mrb_value obj);
 
-FT_Face
-mrb_carbuncle_font_get_face(struct mrb_Font *font);
-
-FT_BitmapGlyph *
-mrb_carbuncle_font_load_glyphs(mrb_state *mrb, FT_Face face, size_t len, const char *message);
-
-Vector2
-mrb_carbuncle_font_calculate_size(size_t len, FT_BitmapGlyph *bmps);
-
-void
-mrb_carbuncle_font_destroy_glyphs(mrb_state *mrb, size_t len, FT_BitmapGlyph *bmps);
-
 struct mrb_Glyph *
 mrb_carbuncle_font_get_glyph(struct mrb_Font *font, FT_UInt codepoint);
 

--- a/mrbgems/carbuncle-graphics/include/carbuncle/font.h
+++ b/mrbgems/carbuncle-graphics/include/carbuncle/font.h
@@ -15,6 +15,7 @@ struct mrb_Glyph
 {
   FT_ULong codepoint;
   FT_BitmapGlyph bmp;
+  size_t offset;
   Rectangle rect;
   Vector2 advance;
   Vector2 margin;
@@ -39,12 +40,7 @@ struct mrb_Font
     size_t max_height;
     size_t total_width;
   } metrics;
-  struct 
-  {
-    size_t width;
-    size_t height;
-    Texture2D texture;
-  } atlas;
+  Texture2D texture;
 };
 
 

--- a/mrbgems/carbuncle-graphics/mrblib/shadow_text.rb
+++ b/mrbgems/carbuncle-graphics/mrblib/shadow_text.rb
@@ -24,11 +24,10 @@ module Carbuncle
 
     attr_accessor :offset
 
-    def initialize
-      @shadow_text = Carbuncle::Text.new
+    def initialize(font = nil)
+      @shadow_text = Carbuncle::Text.new(font)
       @shadow_text.color.set(64, 64, 64)
-      @foreground_text = Carbuncle::Text.new
-      @foreground_text.font = @shadow_text.font
+      @foreground_text = Carbuncle::Text.new(@shadow_text.font)
       @offset = Carbuncle::Point.new(2, 2)
     end
 

--- a/mrbgems/carbuncle-graphics/src/font.c
+++ b/mrbgems/carbuncle-graphics/src/font.c
@@ -396,3 +396,27 @@ mrb_carbuncle_font_destroy_glyphs(mrb_state *mrb, size_t len, FT_BitmapGlyph *bm
   }
   mrb_free(mrb, bmps);
 }
+
+static struct mrb_Glyph *
+find_node(struct mrb_Glyph *current, FT_UInt codepoint)
+{
+  while (current)
+  {
+    if (current->codepoint == codepoint) { return current; }
+    if (current->codepoint < codepoint)
+    {
+      current = current->left;
+    }
+    else
+    {
+      current = current->right;
+    }
+  }
+  return current;
+}
+
+struct mrb_Glyph *
+mrb_carbuncle_font_get_glyph(struct mrb_Font *font, FT_UInt codepoint)
+{
+  return find_node(font->glyphs.root, codepoint);
+}

--- a/mrbgems/carbuncle-graphics/src/font.c
+++ b/mrbgems/carbuncle-graphics/src/font.c
@@ -16,12 +16,18 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
-struct mrb_Font
+static void
+free_glyph(mrb_state *mrb, struct mrb_Glyph *glyph)
 {
-  FT_Face face;
-  mrb_int size;
-};
+  if (glyph)
+  {
+    free_glyph(mrb, glyph->left);
+    free_glyph(mrb, glyph->right);
+    mrb_free(mrb, glyph);
+  }
+}
 
 static void
 mrb_font_free(mrb_state *mrb, void *ptr)
@@ -29,6 +35,10 @@ mrb_font_free(mrb_state *mrb, void *ptr)
   struct mrb_Font *font = ptr;
   if (font)
   {
+    if (font->glyphs.root)
+    {
+      free_glyph(mrb, font->glyphs.root);
+    }
     if (font->face)
     {
       FT_Done_Face(font->face);
@@ -44,6 +54,156 @@ static const struct mrb_data_type font_data_type = {
 static FT_Library carbuncle_freetype;
 
 static void
+glyph_error(mrb_state *mrb)
+{
+  mrb_raise(mrb, mrb->eStandardError_class, "Unable to load font glyphs.");
+}
+
+static mrb_int
+tree_height(struct mrb_Glyph *node)
+{
+  if (!node) { return 0; }
+  mrb_int left, right;
+  left = tree_height(node->left);
+  right = tree_height(node->right);
+  return 1 + (left > right ? left : right);
+}
+
+static struct mrb_Glyph *
+rotate_right(struct mrb_Glyph *y)
+{ 
+  struct mrb_Glyph *x = y->left;
+  struct mrb_Glyph *T2 = x->right;
+  // Perform rotation 
+  x->right = y; 
+  y->left = T2; 
+  // Update heights 
+  y->height = tree_height(y); 
+  x->height = tree_height(x); 
+  // Return new root 
+  return x; 
+} 
+
+static struct mrb_Glyph *
+rotate_left(struct mrb_Glyph *x)
+{
+  struct mrb_Glyph *y = x->right; 
+  struct mrb_Glyph *T2 = y->left; 
+  // Perform rotation 
+  y->left = x; 
+  x->right = T2; 
+  //  Update heights 
+  x->height = tree_height(x); 
+  y->height = tree_height(y); 
+  // Return new root 
+  return y; 
+}
+
+
+static struct mrb_Glyph *
+balance(struct mrb_Glyph *current)
+{
+  mrb_int lh = current->left ? current->left->height : 0;
+  mrb_int rh = current->right ? current->right->height : 0;
+  mrb_int balance = lh - rh;
+  if (balance > 0)
+  {
+    return rotate_right(current);
+  }
+  else if (balance < 0)
+  {
+    return rotate_left(current);
+  }
+  return current;
+}
+
+static inline void
+set_node_data(struct mrb_Glyph *node, FT_BitmapGlyph bmp)
+{
+  node->advance.x = bmp->root.advance.x;
+  node->advance.x = bmp->root.advance.y;
+}
+
+static inline struct mrb_Glyph *
+add_node(mrb_state *mrb, struct mrb_Glyph *current, FT_ULong codepoint, FT_BitmapGlyph bmp)
+{
+  if (!current)
+  {
+    current = mrb_malloc(mrb, sizeof *current);
+    if (!current) { glyph_error(mrb); }
+    current->left = NULL;
+    current->right = NULL;
+    current->codepoint = codepoint;
+    current->bmp = bmp;
+    current->height = 1;
+    set_node_data(current, bmp);
+    return current;
+  }
+  if (current->codepoint == codepoint) { return current; }
+  if (current->codepoint < codepoint)
+  {
+    current->left = add_node(mrb, current->left, codepoint, bmp);
+    current->height = tree_height(current);
+    return balance(current); 
+  }
+  current->right = add_node(mrb, current->right, codepoint, bmp);
+  current->height = tree_height(current);
+  return balance(current);
+}
+
+static inline mrb_int
+min(mrb_int a, mrb_int b)
+{
+  return a < b ? a : b;
+}
+
+#include <assert.h>
+
+static inline FT_BitmapGlyph
+load_glyph(mrb_state *mrb, struct mrb_Font *font, FT_ULong codepoint)
+{
+  FT_Glyph glyph;
+  FT_Matrix matrix = (FT_Matrix){ .xx = 0x10000, .xy = 0, .yx = 0, .yy = 0x10000 };
+	FT_Vector pen = (FT_Vector){ .x = 0, .y = 0};
+  FT_Set_Transform(font->face, &matrix, &pen);
+  if (FT_Load_Char(font->face, codepoint, FT_LOAD_TARGET_NORMAL)) { glyph_error(mrb); }
+  if (FT_Get_Glyph(font->face->glyph, &glyph)) { glyph_error(mrb); }
+  if (FT_Glyph_To_Bitmap(&glyph, FT_RENDER_MODE_NORMAL, 0, 1)) { glyph_error(mrb); }
+  FT_BitmapGlyph bmp = (FT_BitmapGlyph)glyph;
+  font->glyphs.root = add_node(mrb, font->glyphs.root, codepoint, bmp);
+  return bmp;
+}
+
+static inline void
+build_font_atlas(mrb_state *mrb, struct mrb_Font *font)
+{
+}
+
+static inline void
+load_glyphs(mrb_state *mrb, struct mrb_Font *font)
+{
+  FT_UInt min_h, max_h, w, index;
+  FT_ULong character = FT_Get_First_Char(font->face, &index);
+  FT_BitmapGlyph bmp = load_glyph(mrb, font, character);
+  w = bmp->bitmap.width;
+  min_h = bmp->bitmap.rows + bmp->top;
+  character = FT_Get_Next_Char(font->face, character, &index);
+  while (character)
+  {
+    bmp = load_glyph(mrb, font, character);
+    FT_UInt new_h = bmp->bitmap.rows + bmp->top;
+    w = w < bmp->bitmap.width ? bmp->bitmap.width : w;
+    min_h = min_h > new_h ? new_h : min_h;
+    max_h = max_h < new_h ? new_h : max_h;
+    character = FT_Get_Next_Char(font->face, character, &index);
+  }
+  font->metrics.max_width  = w;
+  font->metrics.min_height = min_h;
+  font->metrics.max_height = max_h;
+  build_font_atlas(mrb, font);
+}
+
+static inline void
 open_font(mrb_state *mrb, struct mrb_Font *font, const char *filename, size_t size)
 {
   if (FT_New_Face(carbuncle_freetype, filename, 0, &(font->face)))
@@ -58,6 +218,8 @@ open_font(mrb_state *mrb, struct mrb_Font *font, const char *filename, size_t si
   {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "cannot set font size for font %s.", filename);
   }
+  font->glyphs.root = NULL;
+  load_glyphs(mrb, font);
 }
 
 static mrb_value
@@ -83,10 +245,9 @@ mrb_font_initialize(mrb_state *mrb, mrb_value self)
   struct mrb_Font *font = mrb_malloc(mrb, sizeof *font);
   DATA_PTR(self) = font;
   DATA_TYPE(self) = &font_data_type;
-  size_t str_size = strlen(name) + 1;
   font->face = NULL;
-  mrb_carbuncle_check_file(mrb, name);
   font->size = size;
+  mrb_carbuncle_check_file(mrb, name);
   open_font(mrb, font, name, size);
   return self;
 }
@@ -154,11 +315,7 @@ mrb_carbuncle_font_get_face(struct mrb_Font *font)
   return font->face;
 }
 
-static void
-glyph_error(mrb_state *mrb)
-{
-  mrb_raise(mrb, mrb->eStandardError_class, "Unable to load font glyphs.");
-}
+
 
 FT_BitmapGlyph *
 mrb_carbuncle_font_load_glyphs(mrb_state *mrb, FT_Face face, size_t len, const char *message)
@@ -166,7 +323,7 @@ mrb_carbuncle_font_load_glyphs(mrb_state *mrb, FT_Face face, size_t len, const c
   FT_UInt codepoint;
   FT_Glyph glyph;
   FT_Matrix matrix = (FT_Matrix){ .xx = 0x10000, .xy = 0, .yx = 0, .yy = 0x10000 };
-	FT_Vector pen = (FT_Vector){ .x = 0, .y = 0};  
+	FT_Vector pen = (FT_Vector){ .x = 0, .y = 0};
   FT_BitmapGlyph *bmps = mrb_malloc(mrb, len * sizeof(*bmps));
   for (size_t i = 0; i < len; ++i)
   {

--- a/mrbgems/carbuncle-graphics/src/text.c
+++ b/mrbgems/carbuncle-graphics/src/text.c
@@ -37,6 +37,7 @@ struct mrb_Text
   size_t             len;
   size_t             capa;
   struct mrb_Glyph **glyphs;
+  mrb_int            min_y;
 };
 
 static void
@@ -121,10 +122,14 @@ static void
 load_glyphs(mrb_state *mrb, struct mrb_Text *text, size_t len, const char *message)
 {
   uint32_t codepoint;
+  text->min_y = text->font->metrics.max_height;
   for (size_t i = 0; i < len; ++i)
   {
     message = utf8_decode(message, &codepoint);
-    text->glyphs[i] = mrb_carbuncle_font_get_glyph(text->font, codepoint);
+    struct mrb_Glyph *glyph = mrb_carbuncle_font_get_glyph(text->font, codepoint);
+    text->glyphs[i] = glyph;
+    mrb_int min_y = text->font->metrics.max_height - glyph->margin.y;
+    if (min_y < text->min_y) { text->min_y = min_y; }
   }
 }
 

--- a/mrbgems/carbuncle-graphics/src/text.c
+++ b/mrbgems/carbuncle-graphics/src/text.c
@@ -112,7 +112,12 @@ update_text(mrb_state *mrb, struct mrb_Text *text, const char *message)
 static struct mrb_value
 mrb_text_initialize(mrb_state *mrb, mrb_value self)
 {
-  mrb_value font = mrb_obj_new(mrb, mrb_carbuncle_class_get(mrb, "Font"), 0, NULL);
+  mrb_value font = mrb_nil_value();
+  mrb_get_args(mrb, "|o", &font);
+  if (mrb_nil_p(font))
+  {
+    font = mrb_obj_new(mrb, mrb_carbuncle_class_get(mrb, "Font"), 0, NULL);
+  }
   mrb_value color = mrb_carbuncle_color_new(mrb, 255, 255, 255, 255);
   mrb_value position = mrb_carbuncle_point_new(mrb, 0, 0);
   mrb_iv_set(mrb, self, FONT_SYMBOL, font);
@@ -214,7 +219,7 @@ mrb_carbuncle_text_init(mrb_state *mrb)
 {
   struct RClass *text = mrb_carbuncle_define_data_class(mrb, "Text", mrb->object_class);
 
-  mrb_define_method(mrb, text, "initialize", mrb_text_initialize, MRB_ARGS_NONE());
+  mrb_define_method(mrb, text, "initialize", mrb_text_initialize, MRB_ARGS_OPT(1));
 
   mrb_define_method(mrb, text, "font", mrb_text_get_font, MRB_ARGS_NONE());
   mrb_define_method(mrb, text, "color", mrb_text_get_color, MRB_ARGS_NONE());

--- a/mrbgems/carbuncle-graphics/src/text.c
+++ b/mrbgems/carbuncle-graphics/src/text.c
@@ -123,6 +123,7 @@ load_glyphs(mrb_state *mrb, struct mrb_Text *text, size_t len, const char *messa
 {
   uint32_t codepoint;
   text->min_y = text->font->metrics.max_height;
+  printf("Printing... \"%s\"\n", message);
   for (size_t i = 0; i < len; ++i)
   {
     message = utf8_decode(message, &codepoint);
@@ -250,8 +251,18 @@ static mrb_value
 mrb_text_draw(mrb_state *mrb, mrb_value self)
 {
   struct mrb_Text *text = get_text(mrb, self);
-  if (!text->len) { return self; }
-  DrawTextureV(text->texture, *(text->position), *(text->color));
+  Vector2 position = *(text->position);
+  Color color = *(text->color);
+  for (size_t i = 0; i < text->len; ++i)
+  {
+    struct mrb_Glyph *glyph = text->glyphs[i];
+    Vector2 pos = (Vector2){
+      position.x + glyph->margin.x,
+      position.y + glyph->margin.y
+    };
+    DrawTextureRec(text->font->texture, glyph->rect, pos, color);
+    position.x += glyph->rect.width - glyph->margin.x;
+  }
   return self;
 }
 

--- a/mrbgems/carbuncle-graphics/src/text.c
+++ b/mrbgems/carbuncle-graphics/src/text.c
@@ -123,7 +123,6 @@ load_glyphs(mrb_state *mrb, struct mrb_Text *text, size_t len, const char *messa
 {
   uint32_t codepoint;
   text->min_y = text->font->metrics.max_height;
-  printf("Printing... \"%s\"\n", message);
   for (size_t i = 0; i < len; ++i)
   {
     message = utf8_decode(message, &codepoint);
@@ -258,7 +257,7 @@ mrb_text_draw(mrb_state *mrb, mrb_value self)
     struct mrb_Glyph *glyph = text->glyphs[i];
     Vector2 pos = (Vector2){
       position.x + glyph->margin.x,
-      position.y + glyph->margin.y
+      position.y + text->min_y - glyph->margin.y
     };
     DrawTextureRec(text->font->texture, glyph->rect, pos, color);
     position.x += glyph->rect.width - glyph->margin.x;


### PR DESCRIPTION
This makes possible to load the complete font as an atlas, and then render those rects, instead of drawing the text when changes.

It has less memory usage, and is quite fast.