### PR TITLE
Add multiple load paths

### DIFF
--- a/gems/carbuncle-core/mrblib/file.rb
+++ b/gems/carbuncle-core/mrblib/file.rb
@@ -14,6 +14,51 @@ module Carbuncle
         @required_files.keys
       end
 
+      def join(*names)
+        return '' if names.empty?
+
+        names.filter!(&:present?)
+        names.map! do |name|
+          case name
+          when String
+            name
+          when Array
+            raise ArgumentError, 'recursive array' if names == name
+
+            join(*name)
+          else
+            raise TypeError, "no implicit conversion of #{name.class} into String"
+          end
+        end
+        return names[0] if names.size == 1
+
+        s =
+          if names[0][-1] == Carbuncle::File::SEPARATOR
+            names[0][0..-2]
+          else
+            names[0].dup
+          end
+
+        (1..names.size - 2).each do |i|
+          t = names[i]
+          if t[0] == Carbuncle::File::SEPARATOR && t[-1] == Carbuncle::File::SEPARATOR
+            t = t[1..-2]
+          elsif t[0] == Carbuncle::File::SEPARATOR
+            t = t[1..-1]
+          elsif t[-1] == Carbuncle::File::SEPARATOR
+            t = t[0..-2]
+          end
+          s += Carbuncle::File::SEPARATOR + t if t != ''
+        end
+        s +=
+          if names[-1][0] == Carbuncle::File::SEPARATOR
+            Carbuncle::File::SEPARATOR + names[-1][1..-1]
+          else
+            Carbuncle::File::SEPARATOR + names[-1]
+          end
+        s
+      end
+
       def readlines(name, *args)
         open_args = [name]
         read_args = []

--- a/gems/mruby-bin-carbuncle/tools/mruby-carbuncle/mruby-carbuncle.c
+++ b/gems/mruby-bin-carbuncle/tools/mruby-carbuncle/mruby-carbuncle.c
@@ -81,23 +81,8 @@ set_working_directory(mrb_state *mrb, const char *file)
 static void
 load_main_file(mrb_state *mrb)
 {
-  PHYSFS_sint64 length;
-  const char *str;
-  struct mrbc_context *ctx;
-  mrb_value result;
-#ifdef __EMSCRIPTEN__
-  mrb_carbuncle_fetch_file(mrb, MAIN_FILENAME);
-#endif
-  str = mrb_carbuncle_load_file(mrb, MAIN_FILENAME, &length);
-  ctx = mrbc_context_new(mrb);
-  ctx->filename = (char *)MAIN_FILENAME;
-  ctx->capture_errors = TRUE;
-  result = mrb_load_nstring_cxt(mrb, str, length, ctx);
-  if (mrb->exc)
-  {
-    mrb_exc_raise(mrb, mrb_obj_value(mrb->exc));
-  }
-  mrb_free(mrb, str);
+  mrb_value file = mrb_obj_value(mrb_carbuncle_class_get(mrb, "File"));
+  mrb_funcall(mrb, file, "require", 1, mrb_str_new_cstr(mrb, MAIN_FILENAME));
 }
 
 static void


### PR DESCRIPTION
## Summary

Adds the ability to load scripts for inside the src or scripts folder, instead of only the root folder.

You can modify this behaviour by adding a new load path into `Carbuncle::File.load_paths` However, as main is already loaded by that point I don't know if it really has a lot of utility.
Also, the game now uses `Carbuncle::File.require('main.rb')` instead of a custom code, so it also improves that.